### PR TITLE
Make work on v14 Ubuntu RightImage

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -3,8 +3,11 @@
     "fog": {
       "path": "."
     },
+    "nokogiri": {
+      "locked_version": "0.1.4"
+    },
     "build-essential": {
-      "locked_version": "2.2.2"
+      "locked_version": "2.1.3"
     },
     "libxml2": {
       "locked_version": "0.1.1"
@@ -14,6 +17,21 @@
     },
     "apt": {
       "locked_version": "2.7.0"
+    },
+    "ruby_install": {
+      "locked_version": "1.0.5"
+    },
+    "ark": {
+      "locked_version": "0.9.0"
+    },
+    "windows": {
+      "locked_version": "1.36.6"
+    },
+    "chef_handler": {
+      "locked_version": "1.1.6"
+    },
+    "7-zip": {
+      "locked_version": "1.0.2"
     }
   }
 }

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -3,11 +3,8 @@
     "fog": {
       "path": "."
     },
-    "nokogiri": {
-      "locked_version": "0.1.4"
-    },
     "build-essential": {
-      "locked_version": "2.1.3"
+      "locked_version": "2.2.2"
     },
     "libxml2": {
       "locked_version": "0.1.1"
@@ -17,21 +14,6 @@
     },
     "apt": {
       "locked_version": "2.7.0"
-    },
-    "ruby_install": {
-      "locked_version": "1.0.5"
-    },
-    "ark": {
-      "locked_version": "0.9.0"
-    },
-    "windows": {
-      "locked_version": "1.36.6"
-    },
-    "chef_handler": {
-      "locked_version": "1.1.6"
-    },
-    "7-zip": {
-      "locked_version": "1.0.2"
     }
   }
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures fog'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
 
-
-depends "nokogiri"
+depends "build-essential"
+depends "libxml2"
 
 recipe "fog::default", "installs fog"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures fog'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.0'
 
-depends "build-essential"
-depends "libxml2"
+
+depends "nokogiri"
 
 recipe "fog::default", "installs fog"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'premium@rightscale.com'
 license          'Apache 2.0'
 description      'Installs/Configures fog'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.2.0'
 
 depends "build-essential"
 depends "libxml2"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+package "zlib1g-dev" if node['platform_family'] == "debian"
 include_recipe "build-essential::default"
 include_recipe "libxml2::default"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,9 +17,7 @@
 # limitations under the License.
 #
 
-package "zlib1g-dev" if node['platform_family'] == "debian"
-include_recipe "build-essential::default"
-include_recipe "libxml2::default"
+include_recipe "nokogiri"
 
 chef_gem "fog" do
   compile_time true if respond_to?(:compile_time)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-include_recipe "nokogiri"
+package "zlib1g-dev" if node['platform_family'] == "debian"
+include_recipe "build-essential::default"
+include_recipe "libxml2::default"
 
 chef_gem "fog" do
   compile_time true if respond_to?(:compile_time)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,9 +17,15 @@
 # limitations under the License.
 #
 
-package "zlib1g-dev" if node['platform_family'] == "debian"
 include_recipe "build-essential::default"
 include_recipe "libxml2::default"
+
+if node['platform_family'] == "debian"
+  p= package "zlib1g-dev" do
+    action :nothing
+  end
+  p.run_action(:install)
+end
 
 chef_gem "fog" do
   compile_time true if respond_to?(:compile_time)

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,16 +1,30 @@
 require_relative 'spec_helper'
 
 describe 'fog::default' do
-
+  before{
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_call_original
+    %w(build-essential::default libxml2::default).each do |recipe|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe)
+    end
+  }
   
   let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run_ubuntu) { ChefSpec::Runner.new(platform: 'ubuntu',
+      version: '14.04').converge(described_recipe) }
 
-
-  it 'includes nokogiri' do
-    expect(chef_run).to include_recipe("nokogiri")
+  it "installs zlib package" do
+    expect(chef_run_ubuntu).to install_package("zlib1g-dev")
   end
 
+  it 'includes build-essential' do
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('build-essential::default')
+    chef_run
+  end
 
+  it 'includes libxml-devel' do
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('libxml2::default')
+    chef_run
+  end
 
   it 'installs fog gem' do
     expect(chef_run).to install_chef_gem('fog').with(

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,14 +1,29 @@
 require_relative 'spec_helper'
 
 describe 'fog::default' do
+  before{
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_call_original
+    %w(build-essential::default libxml2::default).each do |recipe|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe)
+    end
+  }
+  
   let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run_ubuntu) { ChefSpec::Runner.new(platform: 'ubuntu',
+      version: '14.04').converge(described_recipe) }
+
+  it "installs zlib package" do
+    expect(chef_run_ubuntu).to install_package("zlib1g-dev")
+  end
 
   it 'includes build-essential' do
-    expect(chef_run).to include_recipe('build-essential::default')
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('build-essential::default')
+    chef_run
   end
 
   it 'includes libxml-devel' do
-    expect(chef_run).to include_recipe('libxml2::default')
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('libxml2::default')
+    chef_run
   end
 
   it 'installs fog gem' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,30 +1,16 @@
 require_relative 'spec_helper'
 
 describe 'fog::default' do
-  before{
-    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_call_original
-    %w(build-essential::default libxml2::default).each do |recipe|
-      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe)
-    end
-  }
+
   
   let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
-  let(:chef_run_ubuntu) { ChefSpec::Runner.new(platform: 'ubuntu',
-      version: '14.04').converge(described_recipe) }
 
-  it "installs zlib package" do
-    expect(chef_run_ubuntu).to install_package("zlib1g-dev")
+
+  it 'includes nokogiri' do
+    expect(chef_run).to include_recipe("nokogiri")
   end
 
-  it 'includes build-essential' do
-    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('build-essential::default')
-    chef_run
-  end
 
-  it 'includes libxml-devel' do
-    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('libxml2::default')
-    chef_run
-  end
 
   it 'installs fog gem' do
     expect(chef_run).to install_chef_gem('fog').with(


### PR DESCRIPTION
Rightimages do not include the correct libs to install fog.  This release adds the correct lib and adds appropriate tests 
